### PR TITLE
Cleaning up bower metadata for eventual publishing

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,10 +8,14 @@
   ],
   "dependencies": {
     "purescript-strings": "^3.0.0",
-    "purescript-halogen": "^2.0.0",
+    "purescript-halogen": "^2.3.0",
     "purescript-dom-indexed": "^3.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0"
+  }
+  , "repository": {
+    "type": "git"
+    , "url" : "https://github.com/AidanDelaney/purescript-halogen-svg.git"
   }
 }


### PR DESCRIPTION
Hi,
I know your readme states that this is proof of concept code, but I wanted to use it in another project.  To do this I've published `purescript-halogen-svg` to bower.  I've also had to add my fork as the upstream repository as bower relies on `git tag` to pull new versions.  This is wrong, it should pull from your repository as you are the upstream.

Would you mind adding yourself as the author in the `bower.json` file?  And, additionally, choosing a licence for your code?  I'm happy to contribute where I can, and I really don't want to use your hard work without appropriate attribution.

Thank you.