### PR TITLE
Add onWheel and onContextMenu events to SVG element

### DIFF
--- a/src/Svg/Indexed.purs
+++ b/src/Svg/Indexed.purs
@@ -1,14 +1,15 @@
 module Svg.Indexed where
 -- Like DOM.HTML.Indexed
 
-import DOM.HTML.Indexed (GlobalEvents, MouseEvents, KeyEvents, ClipboardEvents)
+import DOM.HTML.Indexed (MouseEvents, KeyEvents, ClipboardEvents)
+import DOM.Event.Types (MouseEvent)
 
 type CoreAttributes r = (id :: String | r)
-type GraphicalEventAttributes r = (GlobalEvents (MouseEvents (KeyEvents (ClipboardEvents r))))
+type GraphicalEventAttributes r = ClipboardEvents (KeyEvents (MouseEvents (onContextMenu :: MouseEvent | r)))
 
 type SVGsvg = GraphicalEventAttributes (CoreAttributes (width :: Number, height :: Number, viewBox :: String))
 
-type PresentationAttributes r = (stroke :: String, fill ::String | r)
+type PresentationAttributes r = (stroke :: String, fill :: String | r)
 type GlobalAttributes r = (PresentationAttributes (GraphicalEventAttributes (CoreAttributes (class :: String | r))))
 
 type SVGcircle = GlobalAttributes

--- a/src/Svg/Indexed.purs
+++ b/src/Svg/Indexed.purs
@@ -1,15 +1,15 @@
 module Svg.Indexed where
 -- Like DOM.HTML.Indexed
 
-import DOM.HTML.Indexed (MouseEvents)
+import DOM.HTML.Indexed (GlobalEvents, MouseEvents, KeyEvents, ClipboardEvents)
 
 type CoreAttributes r = (id :: String | r)
-type GraphicalEventAttributes r = MouseEvents r
+type GraphicalEventAttributes r = (GlobalEvents (MouseEvents (KeyEvents (ClipboardEvents r))))
 
 type SVGsvg = GraphicalEventAttributes (CoreAttributes (width :: Number, height :: Number, viewBox :: String))
 
 type PresentationAttributes r = (stroke :: String, fill ::String | r)
-type GlobalAttributes r = (PresentationAttributes (GraphicalEventAttributes (CoreAttributes (class ::String | r))))
+type GlobalAttributes r = (PresentationAttributes (GraphicalEventAttributes (CoreAttributes (class :: String | r))))
 
 type SVGcircle = GlobalAttributes
   ( cx :: Number

--- a/src/Svg/Indexed.purs
+++ b/src/Svg/Indexed.purs
@@ -1,13 +1,17 @@
 module Svg.Indexed where
 -- Like DOM.HTML.Indexed
 
-import DOM.HTML.Indexed (MouseEvents, KeyEvents, ClipboardEvents)
-import DOM.Event.Types (MouseEvent)
+import DOM.HTML.Indexed (MouseEvents)
+import DOM.Event.Types (MouseEvent, WheelEvent)
 
 type CoreAttributes r = (id :: String | r)
-type GraphicalEventAttributes r = ClipboardEvents (KeyEvents (MouseEvents (onContextMenu :: MouseEvent | r)))
+type GraphicalEventAttributes r = MouseEvents r
 
-type SVGsvg = GraphicalEventAttributes (CoreAttributes (width :: Number, height :: Number, viewBox :: String))
+type SVGsvg = GraphicalEventAttributes (CoreAttributes (width :: Number, 
+                                                        height :: Number, 
+                                                        viewBox :: String, 
+                                                        onWheel :: WheelEvent, 
+                                                        onContextMenu :: MouseEvent))
 
 type PresentationAttributes r = (stroke :: String, fill :: String | r)
 type GlobalAttributes r = (PresentationAttributes (GraphicalEventAttributes (CoreAttributes (class :: String | r))))


### PR DESCRIPTION
Not sure if this is the right place to add these events architecturally, but it does work!  `onContextMenu` needs to be added separately since it is not included in `DOM.HTML.Indexed.MouseEvents`, even though it has type `MouseEvent`.