### PR TITLE
Update to Halogen ^5.0.0-rc.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,12 +11,12 @@
     "output"
   ],
   "dependencies": {
-    "purescript-strings": "^3.3.1",
-    "purescript-halogen": "^3.0.1",
-    "purescript-dom-indexed": "^5.0.0"
+    "purescript-strings": "^4.0.1",
+    "purescript-halogen": "^5.0.0-rc.7",
+    "purescript-dom-indexed": "^7.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^3.0.0"
+    "purescript-psci-support": "^4.0.0"
   },
   "repository": {
     "type": "git",

--- a/examples/circle/packages.dhall
+++ b/examples/circle/packages.dhall
@@ -1,0 +1,130 @@
+{-
+Welcome to your new Dhall package-set!
+
+Below are instructions for how to edit this file for most use
+cases, so that you don't need to know Dhall to use it.
+
+## Warning: Don't Move This Top-Level Comment!
+
+Due to how `dhall format` currently works, this comment's
+instructions cannot appear near corresponding sections below
+because `dhall format` will delete the comment. However,
+it will not delete a top-level comment like this one.
+
+## Use Cases
+
+Most will want to do one or both of these options:
+1. Override/Patch a package's dependency
+2. Add a package not already in the default package set
+
+This file will continue to work whether you use one or both options.
+Instructions for each option are explained below.
+
+### Overriding/Patching a package
+
+Purpose:
+- Change a package's dependency to a newer/older release than the
+    default package set's release
+- Use your own modified version of some dependency that may
+    include new API, changed API, removed API by
+    using your custom git repo of the library rather than
+    the package set's repo
+
+Syntax:
+Replace the overrides' "{=}" (an empty record) with the following idea
+The "//" or "⫽" means "merge these two records and
+  when they have the same value, use the one on the right:"
+-------------------------------
+let override =
+  { packageName =
+      upstream.packageName // { updateEntity1 = "new value", updateEntity2 = "new value" }
+  , packageName =
+      upstream.packageName // { version = "v4.0.0" }
+  , packageName =
+      upstream.packageName // { repo = "https://www.example.com/path/to/new/repo.git" }
+  }
+-------------------------------
+
+Example:
+-------------------------------
+let overrides =
+  { halogen =
+      upstream.halogen // { version = "master" }
+  , halogen-vdom =
+      upstream.halogen-vdom // { version = "v4.0.0" }
+  }
+-------------------------------
+
+### Additions
+
+Purpose:
+- Add packages that aren't already included in the default package set
+
+Syntax:
+Replace the additions' "{=}" (an empty record) with the following idea:
+-------------------------------
+let additions =
+  { package-name =
+       { dependencies =
+           [ "dependency1"
+           , "dependency2"
+           ]
+       , repo =
+           "https://example.com/path/to/git/repo.git"
+       , version =
+           "tag ('v4.0.0') or branch ('master')"
+       }
+  , package-name =
+       { dependencies =
+           [ "dependency1"
+           , "dependency2"
+           ]
+       , repo =
+           "https://example.com/path/to/git/repo.git"
+       , version =
+           "tag ('v4.0.0') or branch ('master')"
+       }
+  , etc.
+  }
+-------------------------------
+
+Example:
+-------------------------------
+let additions =
+  { benchotron =
+      { dependencies =
+          [ "arrays"
+          , "exists"
+          , "profunctor"
+          , "strings"
+          , "quickcheck"
+          , "lcg"
+          , "transformers"
+          , "foldable-traversable"
+          , "exceptions"
+          , "node-fs"
+          , "node-buffer"
+          , "node-readline"
+          , "datetime"
+          , "now"
+          ]
+      , repo =
+          "https://github.com/hdgarrood/purescript-benchotron.git"
+      , version =
+          "v7.0.0"
+      }
+  }
+-------------------------------
+-}
+
+
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.4-20191025/packages.dhall sha256:f9eb600e5c2a439c3ac9543b1f36590696342baedab2d54ae0aa03c9447ce7d4
+
+let overrides = {
+     halogen-svg = ../../spago.dhall as Location
+}
+
+let additions = {=}
+
+in  upstream // overrides // additions

--- a/examples/circle/spago.dhall
+++ b/examples/circle/spago.dhall
@@ -1,0 +1,13 @@
+{-
+Welcome to a Spago project!
+You can edit this file as you like.
+-}
+{ name =
+    "svg-example"
+, dependencies =
+    [ "effect", "console", "psci-support", "halogen-svg" ]
+, packages =
+    ./packages.dhall
+, sources =
+    [ "src/**/*.purs", "test/**/*.purs" ]
+}

--- a/examples/circle/src/Main.purs
+++ b/examples/circle/src/Main.purs
@@ -1,6 +1,7 @@
 module Main where
 
 import Prelude
+import Data.Const (Const)
 import Data.Maybe (Maybe(..))
 
 import Effect (Effect)
@@ -14,23 +15,27 @@ import Halogen.VDom.Driver (runUI)
 import Svg.Elements as SE
 import Svg.Attributes as SA
 
-data Query a = ToggleState a
+data Action = ToggleState 
 
 type State = { on :: Boolean }
 
 initialState :: forall t . t -> State
 initialState = const { on: false }
 
-ui :: forall g. H.Component HTML Query Unit Void g
-ui = H.component { initialState, render, eval, receiver: const Nothing }
+ui :: forall g. H.Component HTML (Const Void) Unit Void g
+ui = H.mkComponent { initialState
+                   , render
+                   , eval: H.mkEval H.defaultEval
+                           { handleAction = handleAction }
+                   }
   where
-  render :: State -> H.ComponentHTML Query
+  render :: State -> H.ComponentHTML Action () g
   render state =
     SE.svg [SA.viewBox x y w h]
     [ SE.circle
       [ SA.r (if state.on then w/6.0 else w/3.0)
       , SA.fill $ Just (SA.RGB 0 0 100)
-      , HE.onClick (HE.input_ ToggleState)
+      , HE.onClick (const $ Just ToggleState)
       ]
     ]
 
@@ -40,10 +45,9 @@ ui = H.component { initialState, render, eval, receiver: const Nothing }
     x = -(w / 2.0)
     y = -(h / 2.0)
 
-  eval :: Query ~> H.ComponentDSL State Query Void g
-  eval (ToggleState next) = do
-    _ <- H.modify (\state -> state { on = not state.on })
-    pure next
+  handleAction :: Action -> H.HalogenM State Action () Void g Unit
+  handleAction ToggleState =
+    H.modify_ (\state -> state { on = not state.on })
 
 main :: Effect Unit
 main = runHalogenAff do

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,0 +1,128 @@
+{-
+Welcome to your new Dhall package-set!
+
+Below are instructions for how to edit this file for most use
+cases, so that you don't need to know Dhall to use it.
+
+## Warning: Don't Move This Top-Level Comment!
+
+Due to how `dhall format` currently works, this comment's
+instructions cannot appear near corresponding sections below
+because `dhall format` will delete the comment. However,
+it will not delete a top-level comment like this one.
+
+## Use Cases
+
+Most will want to do one or both of these options:
+1. Override/Patch a package's dependency
+2. Add a package not already in the default package set
+
+This file will continue to work whether you use one or both options.
+Instructions for each option are explained below.
+
+### Overriding/Patching a package
+
+Purpose:
+- Change a package's dependency to a newer/older release than the
+    default package set's release
+- Use your own modified version of some dependency that may
+    include new API, changed API, removed API by
+    using your custom git repo of the library rather than
+    the package set's repo
+
+Syntax:
+Replace the overrides' "{=}" (an empty record) with the following idea
+The "//" or "⫽" means "merge these two records and
+  when they have the same value, use the one on the right:"
+-------------------------------
+let override =
+  { packageName =
+      upstream.packageName // { updateEntity1 = "new value", updateEntity2 = "new value" }
+  , packageName =
+      upstream.packageName // { version = "v4.0.0" }
+  , packageName =
+      upstream.packageName // { repo = "https://www.example.com/path/to/new/repo.git" }
+  }
+-------------------------------
+
+Example:
+-------------------------------
+let overrides =
+  { halogen =
+      upstream.halogen // { version = "master" }
+  , halogen-vdom =
+      upstream.halogen-vdom // { version = "v4.0.0" }
+  }
+-------------------------------
+
+### Additions
+
+Purpose:
+- Add packages that aren't already included in the default package set
+
+Syntax:
+Replace the additions' "{=}" (an empty record) with the following idea:
+-------------------------------
+let additions =
+  { package-name =
+       { dependencies =
+           [ "dependency1"
+           , "dependency2"
+           ]
+       , repo =
+           "https://example.com/path/to/git/repo.git"
+       , version =
+           "tag ('v4.0.0') or branch ('master')"
+       }
+  , package-name =
+       { dependencies =
+           [ "dependency1"
+           , "dependency2"
+           ]
+       , repo =
+           "https://example.com/path/to/git/repo.git"
+       , version =
+           "tag ('v4.0.0') or branch ('master')"
+       }
+  , etc.
+  }
+-------------------------------
+
+Example:
+-------------------------------
+let additions =
+  { benchotron =
+      { dependencies =
+          [ "arrays"
+          , "exists"
+          , "profunctor"
+          , "strings"
+          , "quickcheck"
+          , "lcg"
+          , "transformers"
+          , "foldable-traversable"
+          , "exceptions"
+          , "node-fs"
+          , "node-buffer"
+          , "node-readline"
+          , "datetime"
+          , "now"
+          ]
+      , repo =
+          "https://github.com/hdgarrood/purescript-benchotron.git"
+      , version =
+          "v7.0.0"
+      }
+  }
+-------------------------------
+-}
+
+
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.4-20191025/packages.dhall sha256:f9eb600e5c2a439c3ac9543b1f36590696342baedab2d54ae0aa03c9447ce7d4
+
+let overrides = {=}
+
+let additions = {=}
+
+in  upstream // overrides // additions

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,20 @@
+{-
+Welcome to a Spago project!
+You can edit this file as you like.
+-}
+{ name =
+    "halogen-svg"
+, dependencies =
+    [ "console"
+    , "effect"
+    , "halogen"
+    , "prelude"
+    , "psci-support"
+    , "strings"
+    , "web-uievents"
+    ]
+, packages =
+    ./packages.dhall
+, sources =
+    [ "src/**/*.purs", "test/**/*.purs" ]
+}

--- a/src/Svg/Core.purs
+++ b/src/Svg/Core.purs
@@ -4,18 +4,22 @@ module Core where
 import Prelude
 import Data.Maybe (Maybe(..))
 import Halogen.HTML.Core (HTML, Prop(Attribute), Namespace(Namespace), AttrName(AttrName))
-import Halogen.VDom (ElemName, ElemSpec(ElemSpec), VDom(Elem))
+import Halogen.VDom (ElemName, VDom(Elem))
 import Unsafe.Coerce (unsafeCoerce)
 
 ns :: Maybe Namespace
 ns = Just $ Namespace "http://www.w3.org/2000/svg"
 
-element :: forall p i. ElemName -> Array (Prop i) -> Array (HTML p i) -> HTML p i
-element = coe (\name props children -> Elem (ElemSpec ns name props) children)
+element :: forall w i. ElemName -> Array (Prop i) -> Array (HTML w i) -> HTML w i
+element =
+  coe (\name props children -> Elem ns name props children)
   where
-    coe :: (ElemName -> Array (Prop i) -> Array (VDom (Array (Prop i)) p) -> VDom (Array (Prop i)) p)
-        -> ElemName -> Array (Prop i) -> Array (HTML p i) -> HTML p i
-    coe = unsafeCoerce
+  coe
+    :: (ElemName -> Array (Prop i) -> Array (VDom (Array (Prop i)) w) -> VDom (Array (Prop i)) w)
+    -> ElemName -> Array (Prop i) -> Array (HTML w i) -> HTML w i
+  coe = unsafeCoerce
+
+         
 
 attr :: forall i. AttrName -> String -> Prop i
 attr (AttrName name) = Attribute Nothing name

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,7 +1,7 @@
 module Test.Main where
 
 import Prelude
-import Halogen as H
+import Halogen.HTML as HH
 import Svg.Attributes as SA
 import Svg.Elements as SE
 import Effect (Effect)
@@ -9,7 +9,7 @@ import Effect.Console (log)
 
 -- smoke test
 
-render :: forall t1 t2 t3 . t1 -> H.HTML t2 t3
+render :: forall t1 t2 t3 . t1 -> HH.HTML t2 t3
 render state =
   SE.svg [ SA.viewBox 0.0 0.0 100.0 100.0 ] [ SE.circle [ SA.r 10.0 ] ]
 


### PR DESCRIPTION
Have updated to Halogen v5. The main change is ElemSpec is no longer used, its params are now passed directly to Elem.

I have also updated the test and example code to work with v5. Also added spago.dhall files so it now builds with Spago.